### PR TITLE
新增微信小程序的发货信息录入和物流公司编码查询

### DIFF
--- a/app/lang/cht.php
+++ b/app/lang/cht.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'openid不能為空',
                 'template_id_empty_tips'            => 'template_ id不能為空',
                 'data_empty_tips'                   => 'data不能為空',
+                'trade_no_empty_tips'               => 'trade_no不能為空',
+                'buyer_user_empty_tips'             => 'buyer_user不能為空',
+                'goods_title_empty_tips'            => 'goods_title不能為空',
+                'no_match_logistics_company_code'   => '無匹配的物流公司編碼',
+                'no_match_logistics_mode'           => '無匹配的物流模式',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/de.php
+++ b/app/lang/de.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'Openid kann nicht leer sein',
                 'template_id_empty_tips'            => 'template_ ID kann nicht leer sein',
                 'data_empty_tips'                   => 'Daten können nicht leer sein',
+                'trade_no_empty_tips'               => 'trade_no nicht leer sein',
+                'buyer_user_empty_tips'             => 'buyer_user nicht leer sein',
+                'goods_title_empty_tips'            => 'goods_title nicht leer sein',
+                'no_match_logistics_company_code'   => 'Kein passender Logistikunternehmenscode',
+                'no_match_logistics_mode'           => 'Kein passender Logistikmodus',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/en.php
+++ b/app/lang/en.php
@@ -2642,9 +2642,14 @@ return [
             ],
             // 微信
             'wechat'        => [
-                'touser_openid_empty_tips'          => 'Openid cannot be empty',
-                'template_id_empty_tips'            => 'template_ ID cannot be empty',
-                'data_empty_tips'                   => 'Data cannot be empty',
+                'touser_openid_empty_tips'          => 'touser_openid cannot be empty',
+                'template_id_empty_tips'            => 'template_id cannot be empty',
+                'data_empty_tips'                   => 'data cannot be empty',
+                'trade_no_empty_tips'               => 'trade_no cannot be empty',
+                'buyer_user_empty_tips'             => 'buyer_user cannot be empty',
+                'goods_title_empty_tips'            => 'goods_title cannot be empty',
+                'no_match_logistics_company_code'   => 'No matching logistics company code',
+                'no_match_logistics_mode'           => 'No matching logistics mode',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/fra.php
+++ b/app/lang/fra.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'Openid ne peut pas être vide',
                 'template_id_empty_tips'            => 'Template ID ne peut pas être vide',
                 'data_empty_tips'                   => 'Data ne peut pas être vide',
+                'trade_no_empty_tips'               => 'trade_no ne peut pas être vide',
+                'buyer_user_empty_tips'             => 'buyser_user ne peut pas être vide',
+                'goods_title_empty_tips'            => 'goods_title ne peut pas être vide',
+                'no_match_logistics_company_code'   => 'Aucun code de société de logistique correspondant',
+                'no_match_logistics_mode'           => 'Aucun mode de logistique correspondant',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/it.php
+++ b/app/lang/it.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'Openid non può essere vuoto',
                 'template_id_empty_tips'            => 'template_ LID non può essere vuoto',
                 'data_empty_tips'                   => 'I dati non possono essere vuoti',
+                'trade_no_empty_tips'               => 'trade_no non può essere vuoto',
+                'buyer_user_empty_tips'             => 'buyer_user non può essere vuoto',
+                'goods_title_empty_tips'            => 'goods_title non può essere vuoto',
+                'no_match_logistics_company_code'   => 'Nessun codice aziendale di logistica corrispondente',
+                'no_match_logistics_mode'           => 'Nessuna modalità di logistica corrispondente',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/jp.php
+++ b/app/lang/jp.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'openidを空にすることはできません',
                 'template_id_empty_tips'            => 'template_idを空にすることはできません',
                 'data_empty_tips'                   => 'dataを空にすることはできません',
+                'trade_no_empty_tips'               => 'trade_noを空にすることはできません',
+                'buyer_user_empty_tips'             => 'buyer_userを空にすることはできません',
+                'goods_title_empty_tips'            => 'goods_titleを空にすることはできません',
+                'no_match_logistics_company_code'   => '一致する物流会社コードがありません',
+                'no_match_logistics_mode'           => '一致する物流モードがありません',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/kor.php
+++ b/app/lang/kor.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'openid는 비워둘 수 없습니다.',
                 'template_id_empty_tips'            => 'template_id는 비워둘 수 없습니다.',
                 'data_empty_tips'                   => '데이터는 비워둘 수 없습니다.',
+                'trade_no_empty_tips'               => 'trade_no 비워둘 수 없습니다',
+                'buyer_user_empty_tips'             => 'buyer_user 비워둘 수 없습니다',
+                'goods_title_empty_tips'            => 'goods_title 비워둘 수 없습니다',
+                'no_match_logistics_company_code'   => '일치하는 물류 회사 코드가 없습니다',
+                'no_match_logistics_mode'           => '일치하는 물류 모드가 없습니다',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/nl.php
+++ b/app/lang/nl.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'Openid kan niet leeg zijn',
                 'template_id_empty_tips'            => 'sjabloon_ ID kan niet leeg zijn',
                 'data_empty_tips'                   => 'Gegevens kunnen niet leeg zijn',
+                'trade_no_empty_tips'               => 'trade_no niet leeg zijn',
+                'buyer_user_empty_tips'             => 'buyer_user niet leeg zijn',
+                'goods_title_empty_tips'            => 'goods_title niet leeg zijn',
+                'no_match_logistics_company_code'   => 'Geen overeenkomende logistiek bedrijfscode',
+                'no_match_logistics_mode'           => 'Geen overeenkomende logistiek modus',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/ru.php
+++ b/app/lang/ru.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'OpenID не может быть пустым',
                 'template_id_empty_tips'            => 'Текст ID не может быть пустым',
                 'data_empty_tips'                   => 'Данные не могут быть пустыми',
+                'trade_no_empty_tips'               => 'trade_no не может быть пустым',
+                'buyer_user_empty_tips'             => 'buyer_user не может быть пустым',
+                'goods_title_empty_tips'            => 'goods_title не может быть пустым',
+                'no_match_logistics_company_code'   => 'Нет соответствующего кода логистической компании',
+                'no_match_logistics_mode'           => 'Нет соответствующего режима логистики',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/spa.php
+++ b/app/lang/spa.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'OpenID no puede estar vacío',
                 'template_id_empty_tips'            => 'Plantilla El ID no puede estar vacío',
                 'data_empty_tips'                   => 'Los datos no pueden estar vacíos',
+                'trade_no_empty_tips'               => 'trade_no no puede estar vacío',
+                'buyer_user_empty_tips'             => 'buyer_user no puede estar vacío',
+                'goods_title_empty_tips'            => 'goods_title no puede estar vacío',
+                'no_match_logistics_company_code'   => 'No hay un código de empresa de logística correspondiente',
+                'no_match_logistics_mode'           => 'No hay un modo de logística correspondiente',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/swe.php
+++ b/app/lang/swe.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'Openid kan inte vara tom',
                 'template_id_empty_tips'            => 'mall_ ID kan inte vara tomt',
                 'data_empty_tips'                   => 'Data kan inte vara tom',
+                'trade_no_empty_tips'               => 'trade_no inte vara tomt',
+                'buyer_user_empty_tips'             => 'buyer_user inte vara tom',
+                'goods_title_empty_tips'            => 'goods_title inte vara tom',
+                'no_match_logistics_company_code'   => 'Ingen matchande logistikföretagskod',
+                'no_match_logistics_mode'           => 'Ingen matchande logistikläge',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/th.php
+++ b/app/lang/th.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'openid ไม่สามารถว่างได้',
                 'template_id_empty_tips'            => 'template_ ID ต้องไม่ว่างเปล่า',
                 'data_empty_tips'                   => 'ข้อมูลไม่สามารถว่างได้',
+                'trade_no_empty_tips'               => 'trade_no ต้องไม่เป็นค่าว่าง',
+                'buyer_user_empty_tips'             => 'buyer_user ต้องไม่เป็นค่าว่าง',
+                'goods_title_empty_tips'            => 'goods_title ต้องไม่เป็นค่าว่าง',
+                'no_match_logistics_company_code'   => 'ไม่มีรหัสบริษัทขนส่งที่ตรงกัน',
+                'no_match_logistics_mode'           => 'ไม่มีโหมดการขนส่งที่ตรงกัน',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/vie.php
+++ b/app/lang/vie.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'OpenID không thể rỗng',
                 'template_id_empty_tips'            => 'template_ ID không thể rỗng',
                 'data_empty_tips'                   => 'Data không thể để trống',
+                'trade_no_empty_tips'               => 'trade_no không được để trống',
+                'buyer_user_empty_tips'             => 'buyer_user không được để trống',
+                'goods_title_empty_tips'            => 'goods_title không được để trống',
+                'no_match_logistics_company_code'   => 'Không có mã công ty logistics phù hợp',
+                'no_match_logistics_mode'           => 'Không có chế độ logistics phù hợp',
             ],
             // 邮件
             'email'         => [

--- a/app/lang/zh.php
+++ b/app/lang/zh.php
@@ -2650,6 +2650,11 @@ return [
                 'touser_openid_empty_tips'          => 'openid不能为空',
                 'template_id_empty_tips'            => 'template_id不能为空',
                 'data_empty_tips'                   => 'data不能为空',
+                'trade_no_empty_tips'               => 'trade_no不能为空',
+                'buyer_user_empty_tips'             => 'buyer_user不能为空',
+                'goods_title_empty_tips'            => 'goods_title不能为空',
+                'no_match_logistics_company_code'   => '无匹配的物流公司编码',
+                'no_match_logistics_mode'           => '无匹配的物流模式',
             ],
             // 邮件
             'email'         => [


### PR DESCRIPTION
## 背景
根据微信[小程序发货信息管理服务](https://developers.weixin.qq.com/miniprogram/dev/platform-capabilities/business-capabilities/order-shipping/order-shipping.html)要求，将在微信小程序录入发货信息与微信支付结算挂钩：
> 根据[《商家自营类小程序运营规范》](https://developers.weixin.qq.com/miniprogram/product/jiaoyilei/yunyingguifan.html#%E5%95%86%E5%AE%B6%E8%87%AA%E8%90%A5%E7%B1%BB%E5%B0%8F%E7%A8%8B%E5%BA%8F%E8%BF%90%E8%90%A5%E8%A7%84%E8%8C%83),特定类型的小程序需要在平台完成发货信息录入及确认收货流程后方可进行资金结算。

## 目的
实现当商城系统发货时，自动同步发货信息及状态到微信小程序。无需手动登录微信小程序后台填写。

## 自测
**以下场景都发生在微信小程序内：**`client_type = weixin`  
1. 快递：用户支付，后台点发货，勾选快递公司，填写快递单号，提交后，用户收到通知，点击查询物流信息
1.1 德邦快递：
![image](https://github.com/gongfuxiang/shopxo/assets/4961543/01f660a0-3abe-4ffe-80c7-b5532a13d499)
1.2 申通快递：
![image](https://github.com/gongfuxiang/shopxo/assets/4961543/80d822cd-59b9-433f-ac16-d6ee0d5a7542)
1.3 顺丰速运：
![image](https://github.com/gongfuxiang/shopxo/assets/4961543/cfac16dc-b6c7-4d95-8911-a9e9b8797364)

以下物流公司已测试，可发货，可查询物流轨迹：
1.4 韵达速递
1.5 圆通速递
1.6 中通快递
1.7 极兔速递
1.8 邮政快递包裹
1.9 EMS
1.10 京东快递

其中，顺丰速运，无论提供加星，如`131****1234`，还是完整手机号，首次查询，都需要二次输入手机尾号：
![image](https://github.com/gongfuxiang/shopxo/assets/4961543/7c7f27ec-202b-497e-a5b5-eb9d73cdf355)
2. 自提：后台输入用户提供的自提码后，用户收到通知。对应微信小程序，用户自提发货。无需物流信息
![image](https://github.com/gongfuxiang/shopxo/assets/4961543/57414187-f136-4ed7-a319-031134d26cb6)
3. 虚拟商品：用户支付，系统自动发货后，用户收到通知。对应微信小程序，虚拟发货。无需物流信息
![image](https://github.com/gongfuxiang/shopxo/assets/4961543/2bafbfbe-adc1-42cb-b0e3-5e2a303400fa)

## 修改
1. [extend/base/Wechat.php](https://github.com/gongfuxiang/shopxo/compare/master...mantoufan:wechat-miniapp-upload-shipping-info?expand=1#diff-f28296d7eda82a93a224cd5246acb4b3d7a8c7095c7b640aa594e42cc1e3f6cc)
- 新增 `GetMiniDeliveryIdByName` 实例方法：根据快递公司名称找到其在微信小程序物流中，对应的公司编码。未找到抛出 `no_match_logistics_company_code` 错误。
- 新增 `MiniUploadShippingInfo` 实例方法：该方法签名中，`trade_no` `buyer_user` `goods_title` 为必填项，缺少将抛出相应的不能为空 `**_empty_tips` 错误。当商品处于非以上 3 种模式，如展示模式下，请求接口不报错，但返回 `no_match_logistics_mode` 无匹配的物流模式信息。
- 原 667 行，新增 `json_encode` 的第二参数 `JSON_UNESCAPED_UNICODE`，避免中文转为 `Unicode` 编码，修复如图问题：
![image](https://github.com/gongfuxiang/shopxo/assets/4961543/dc22ba12-daba-4220-8580-2a101e00d487)
此处修改可能需要回归其它功能  

2. [app/service/OrderService.php](https://github.com/gongfuxiang/shopxo/compare/master...mantoufan:wechat-miniapp-upload-shipping-info?expand=1#diff-633d6f6836a1fb62a66c40e799c6b9ea55aa1597df1268784b720e60a8dd41f1)
- 修改 `OrderPayHandle` 方法，若订单为虚拟商品，调用发货时，将 `trade_no` `buyer_user` 传入（因为此时 `pay_log` 未写入）
- 修改 `OrderDeliveryHandle` 方法，对于 `client_type = weixin` 的订单，获取商品名称、物流公司、收件人电话后，经由 `AppMiniUserService` 创建 `Wechat` 实例转译后，调用小程序接口，录入小程序发货信息，通知用户